### PR TITLE
Added GDT initialization

### DIFF
--- a/kernel/arch/i386/boot.S
+++ b/kernel/arch/i386/boot.S
@@ -99,9 +99,16 @@ higher_half:
 
     # These two registers contain multiboot magic and multiboot info pointers
     # respectively. We must push them to stack at boot so that they can be used
-    # by kmain
+    # by kmain. We need to be careful not to modify these before pushing them 
+	# to the stack.
     push %eax
     push %ebx
+
+	# enable A20 line
+	call enable_a20_fast
+
+	# initialize and enter protected mode
+	call pmode_init
 
 	# Enter the high-level kernel.
 	call kmain 
@@ -111,3 +118,36 @@ higher_half:
 idle_loop:
     hlt
 	jmp idle_loop
+
+enable_a20_fast:
+	inb $0x92, %al
+	orb $2, %al
+	outb %al, $0x92
+	ret
+
+# pmode_init enables protected mode
+pmode_init:
+	# disable interrupts
+	cli
+	# initialize Global Descriptor Table (GDT)
+	call gdt_init
+	# enable PE (protection enabled bit) in control register 0
+	movl %cr0, %eax
+	orl $1, %eax
+	movl %eax, %cr0
+	# Reload CS register containing code selector. 0x08 is the kernel code 
+	# segment in the GDT (index 1)
+	ljmp $0x08, $.reload_CS
+	# jmp .reload_CS
+
+.reload_CS:
+	# reload segment registers. 0x10 corresponds to the kernel data segment
+	movw $0x10, %ax
+	movw %ax, %ds
+	movw %ax, %es
+	movw %ax, %fs
+	movw %ax, %gs
+	movw %ax, %ss
+	# re-enable interrupts and return
+	sti
+	ret

--- a/kernel/arch/i386/gdt.c
+++ b/kernel/arch/i386/gdt.c
@@ -3,37 +3,88 @@
 #include <stdlib.h>
 
 extern uint64_t _gdt_start[];
-extern uint64_t _gdt_end[];
 
+uint64_t gdt[NUM_GDT_ENTRIES] __attribute__((section(".gdt")));
+
+/**
+ * sets entry `entry_num` as `source` in the GDT
+ */
 static void set_gdt_entry(int entry_num, struct gdt_entry source);
 
-static struct gdt_entry kernel_code_seg = {
-	.limit	= 0xFFFFF,
-	.base	= 0,
+static struct gdt_entry null_descriptor_seg = {
+	.limit = 0xFFFFF,
+	.base = 0,
 	.access_byte = 0x00,
-	.flags	= 0xC,
+	.flags = 0x0,
+};
+
+static struct gdt_entry kernel_code_seg = {
+	.limit = 0xFFFFF,
+	.base = 0,
+	.access_byte = 0x9A,
+	.flags = 0xC,
+};
+
+static struct gdt_entry kernel_data_seg = {
+	.limit = 0xFFFFF,
+	.base = 0,
+	.access_byte = 0x92,
+	.flags = 0xC,
+};
+
+static struct gdt_entry user_code_seg = {
+	.limit = 0xFFFFF,
+	.base = 0,
+	.access_byte = 0xFA,
+	.flags = 0xC,
+};
+
+static struct gdt_entry user_data_seg = {
+	.limit = 0xFFFFF,
+	.base = 0,
+	.access_byte = 0xF2,
+	.flags = 0xC,
+};
+
+static struct gdt_entry task_state_seg = {
+	.limit = 0x104, // should be size of TSS
+	.base = 0,
+	.access_byte = 0x92,
+	.flags = 0x0,
 };
 
 void gdt_init()
 {
-	// the 0th entry should always be the null descriptor
-	_gdt_start[0] = 0x0;
+	// we opt for a 6-segment flat model in protected mode.
+	set_gdt_entry(0, null_descriptor_seg);
 	set_gdt_entry(1, kernel_code_seg);
+	set_gdt_entry(2, kernel_data_seg);
+	set_gdt_entry(3, user_code_seg);
+	set_gdt_entry(4, user_data_seg);
+	set_gdt_entry(5, task_state_seg);
+
+	struct gdtr gdtr = {
+		.limit = sizeof(uint64_t) * 6, // each GDT entry is 8-bytes
+		.base = (uint32_t)&gdt,
+	};
+
+	// tell the CPU where to find the GDT by loading it into the GDTR
+	asm volatile("lgdt %0" ::"m"(gdtr));
 }
 
 static void set_gdt_entry(int entry_num, const struct gdt_entry source)
 {
-	if (_gdt_start + entry_num > _gdt_end || entry_num == 0)
+	if (entry_num >= NUM_GDT_ENTRIES || entry_num < 0)
 		panic("invalid entry number for gdt entry");
 
 	if (source.limit > 0xFFFFF)
 		panic("gdt entry limit should not exceed 0xFFFFF (20 bits)");
 
-	char *target = (char *)(_gdt_start + entry_num);
+	char *target = (char *)(&gdt[entry_num]);
 
 	target[0] = source.limit & 0xFF;
 	target[1] = (source.limit >> 8) & 0xFF;
-	target[6] = (source.limit >> 16) & 0xF;
+	target[6] = (source.limit >> 16) & 0x0F;
 
 	target[2] = source.base & 0xFF;
 	target[3] = (source.base >> 8) & 0xFF;
@@ -41,5 +92,5 @@ static void set_gdt_entry(int entry_num, const struct gdt_entry source)
 	target[7] = (source.base >> 24) & 0xFF;
 
 	target[5] = source.access_byte;
-	target[6] |= (source.flags & 0xF) << 4;
+	target[6] |= (source.flags) << 4;
 }

--- a/kernel/arch/i386/gdt.c
+++ b/kernel/arch/i386/gdt.c
@@ -1,0 +1,45 @@
+#include <kernel/gdt.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern uint64_t _gdt_start[];
+extern uint64_t _gdt_end[];
+
+static void set_gdt_entry(int entry_num, struct gdt_entry source);
+
+static struct gdt_entry kernel_code_seg = {
+	.limit	= 0xFFFFF,
+	.base	= 0,
+	.access_byte = 0x00,
+	.flags	= 0xC,
+};
+
+void gdt_init()
+{
+	// the 0th entry should always be the null descriptor
+	_gdt_start[0] = 0x0;
+	set_gdt_entry(1, kernel_code_seg);
+}
+
+static void set_gdt_entry(int entry_num, const struct gdt_entry source)
+{
+	if (_gdt_start + entry_num > _gdt_end || entry_num == 0)
+		panic("invalid entry number for gdt entry");
+
+	if (source.limit > 0xFFFFF)
+		panic("gdt entry limit should not exceed 0xFFFFF (20 bits)");
+
+	char *target = (char *)(_gdt_start + entry_num);
+
+	target[0] = source.limit & 0xFF;
+	target[1] = (source.limit >> 8) & 0xFF;
+	target[6] = (source.limit >> 16) & 0xF;
+
+	target[2] = source.base & 0xFF;
+	target[3] = (source.base >> 8) & 0xFF;
+	target[4] = (source.base >> 16) & 0xFF;
+	target[7] = (source.base >> 24) & 0xFF;
+
+	target[5] = source.access_byte;
+	target[6] |= (source.flags & 0xF) << 4;
+}

--- a/kernel/arch/i386/linker.ld
+++ b/kernel/arch/i386/linker.ld
@@ -8,19 +8,19 @@ SECTIONS
 	/* Note that we page-align the sections. Hence 4K! */
 
 	_kernel_start = .;
-        .multiboot.data : {
-            *(.multiboot.data)
-        }
+	.multiboot.data : {
+		*(.multiboot.data)
+	}
 
-       .multiboot.text : {
-           *(.multiboot.text)
-       }
+	.multiboot.text : {
+		*(.multiboot.text)
+   }
 
-	/* here we increment the virtual memory counter by 0xC0000000 */
-	. += 0xC0000000;
-	/* Add a symbol that indicates the start address of the kernel. 
-	 * The `AT` indicates that the physical address is placed 0xC0000000 lower! 
-	 * I.e. the physical location is in the lower memory section. */
+   /* here we increment the virtual memory counter by 0xC0000000 */
+   . += 0xC0000000;
+   /* Add a symbol that indicates the start address of the kernel. 
+	* The `AT` indicates that the physical address is placed 0xC0000000 lower! 
+	* I.e. the physical location is in the lower memory section. */
 	.text ALIGN (4K) : AT (ADDR (.text) - 0xC0000000)
 	{
 		*(.text)
@@ -33,11 +33,18 @@ SECTIONS
 	{
 		*(.data)
 	}
+	/* GDT (Global Descriptor Table) section */
+	.gdt ALIGN (4K) : AT (ADDR (.gdt) - 0xC0000000)
+	{
+		_gdt_start = .;
+		*(.gdt)
+		_gdt_end = .;
+	}
 	.bss ALIGN (4K) : AT (ADDR (.bss) - 0xC0000000)
 	{
 		*(COMMON)
-		*(.bss)
-		*(.bootstrap_stack)
+			*(.bss)
+			*(.bootstrap_stack)
 	}
 	/* Add a symbol that indicates the end address of the kernel. */
 	_kernel_end = .;

--- a/kernel/arch/i386/make.config
+++ b/kernel/arch/i386/make.config
@@ -7,3 +7,4 @@ KERNEL_ARCH_OBJS=\
 $(ARCHDIR)/boot.o \
 $(ARCHDIR)/tty.o \
 $(ARCHDIR)/phys_mem_manager.o \
+$(ARCHDIR)/gdt.o \

--- a/kernel/include/kernel/gdt.h
+++ b/kernel/include/kernel/gdt.h
@@ -1,0 +1,19 @@
+#ifndef _GDT_H
+#define _GDT_H
+
+#include <stdint.h>
+
+// initializes the global descriptor table
+void gdt_init();
+
+/**
+ * defines the fields in a gdt entry
+ */
+struct __attribute__((packed)) gdt_entry {
+	uint32_t limit;
+	uint32_t base;
+	uint8_t access_byte;
+	uint8_t flags;
+};
+
+#endif

--- a/kernel/include/kernel/gdt.h
+++ b/kernel/include/kernel/gdt.h
@@ -3,17 +3,30 @@
 
 #include <stdint.h>
 
-// initializes the global descriptor table
+#define NUM_GDT_ENTRIES 6
+
+/**
+ * initializes the global descriptor table (GDT)
+ */
 void gdt_init();
 
 /**
- * defines the fields in a gdt entry
+ * defines the fields in a GDT entry
  */
 struct __attribute__((packed)) gdt_entry {
 	uint32_t limit;
 	uint32_t base;
 	uint8_t access_byte;
 	uint8_t flags;
+};
+
+/**
+ * defines the layout of the GDTR which is loaded into the GDTR register, which
+ * is 48 bits in width
+ */
+struct __attribute__((packed)) gdtr {
+	uint16_t limit; // the size of the GDT in bytes
+	uint32_t base; // points to the start of the GDT
 };
 
 #endif


### PR DESCRIPTION
Added basic flat model segmentation config for protected mode, which is now activated. This includes 6 distinct segments

- null descriptor (required as entry 0 in GDT)
- Kernel code
- Kernel data
- user mode code
- user mode data
- Task state segment. **WARNING:** this is not yet correct initialized. This, along with other system segment descriptors, will need to be properly initialized in due time before multitasking can be implemented.

Seems to work locally.